### PR TITLE
Eval loss is now always available as a metric

### DIFF
--- a/tensorflow_model_analysis/eval_saved_model/load.py
+++ b/tensorflow_model_analysis/eval_saved_model/load.py
@@ -134,7 +134,11 @@ class EvalSavedModel(object):
         else:
           raise ValueError('unrecognised suffix for metric. key was: %s' % k)
 
-      metric_ops = {}
+      metric_ops = {
+        'loss': tf.metrics.mean(
+          tf.saved_model.utils.get_tensor_from_tensor_info(
+            signature_def.outputs['loss'], self._graph))
+      }
       for metric_name, ops in metrics_map.items():
         metric_ops[metric_name] = (ops[encoding.VALUE_OP_SUFFIX],
                                    ops[encoding.UPDATE_OP_SUFFIX])


### PR DESCRIPTION
It is often handy to inspect the dependence of the pointwise loss on
values of a specific column. IIUC the only way of doing this with TFMA
prior to this commit is adding a "fake" metric

    eval_metric_ops={"eval-loss": tf.metrics.mean(loss)}

The name "loss" is reserved for the actual loss, therefore the users
are forced to use something different.