### PR TITLE
Add transform_dir to parser and fix preprocess_local.sh

### DIFF
--- a/examples/chicago_taxi/preprocess.py
+++ b/examples/chicago_taxi/preprocess.py
@@ -194,6 +194,12 @@ def main():
       help='Filename prefix for emitted transformed examples')
 
   parser.add_argument(
+      '--transform_dir',
+      required=False,
+      default=None,
+      help='Directory in which the transform output is located')
+
+  parser.add_argument(
       '--max_rows',
       help='Number of rows to query from BigQuery',
       default=None,
@@ -205,6 +211,7 @@ def main():
       outfile_prefix=known_args.outfile_prefix,
       working_dir=known_args.output_dir,
       schema_file=known_args.schema_file,
+      transform_dir=known_args.transform_dir,
       max_rows=known_args.max_rows,
       pipeline_args=pipeline_args)
 

--- a/examples/chicago_taxi/preprocess_local.sh
+++ b/examples/chicago_taxi/preprocess_local.sh
@@ -16,16 +16,6 @@ set -u
 
 echo Starting local TFT preprocessing...
 
-# Preprocess the eval files
-echo Preprocessing eval data...
-rm -R -f ./data/eval/local_chicago_taxi_output
-python preprocess.py \
-  --input ./data/eval/data.csv \
-  --schema_file ./data/local_tfdv_output/schema.pbtxt \
-  --output_dir ./data/eval/local_chicago_taxi_output \
-  --outfile_prefix eval_transformed \
-  --runner DirectRunner
-
 # Preprocess the train files, keeping the transform functions
 echo Preprocessing train data...
 rm -R -f ./data/train/local_chicago_taxi_output
@@ -34,4 +24,15 @@ python preprocess.py \
   --schema_file ./data/local_tfdv_output/schema.pbtxt \
   --output_dir ./data/train/local_chicago_taxi_output \
   --outfile_prefix train_transformed \
+  --runner DirectRunner
+
+# Preprocess the eval files
+echo Preprocessing eval data...
+rm -R -f ./data/eval/local_chicago_taxi_output
+python preprocess.py \
+  --input ./data/eval/data.csv \
+  --schema_file ./data/local_tfdv_output/schema.pbtxt \
+  --output_dir ./data/eval/local_chicago_taxi_output \
+  --outfile_prefix eval_transformed \
+  --transform_dir ./data/train/local_chicago_taxi_output \
   --runner DirectRunner


### PR DESCRIPTION
* Added `transform_dir` to parser to that evaluation data can use the transform result from training data directly in `preprocess_local.sh`
* Reversed the execution order in `preprocess_local.sh` since train data needs to be processed first