### PR TITLE
Switch to use `tft.compute_and_apply_vocabulary()`

### DIFF
--- a/examples/chicago_taxi/preprocess.py
+++ b/examples/chicago_taxi/preprocess.py
@@ -95,7 +95,7 @@ def transform_data(input_handle,
 
     for key in taxi.VOCAB_FEATURE_KEYS:
       # Build a vocabulary for this feature.
-      outputs[taxi.transformed_name(key)] = transform.string_to_int(
+      outputs[taxi.transformed_name(key)] = transform.compute_and_apply_vocabulary(
           _fill_in_missing(inputs[key]),
           top_k=taxi.VOCAB_SIZE,
           num_oov_buckets=taxi.OOV_SIZE)


### PR DESCRIPTION
`tft.string_to_int()` is deprecated. 
