### PR TITLE
Update preprocess code to work with tf.transform v0.11.0

### DIFF
--- a/examples/chicago_taxi/setup.py
+++ b/examples/chicago_taxi/setup.py
@@ -31,5 +31,5 @@ if __name__ == '__main__':
           'tensorflow-metadata==0.9.0',
           'tensorflow-model-analysis==0.9.1',
           'tensorflow-serving-api==1.9.0',
-          'tensorflow-transform==0.9.0',
+          'tensorflow-transform==0.11.0',
       ])


### PR DESCRIPTION
According to [v0.11.0 release description](https://github.com/tensorflow/transform/releases/tag/v0.11.0):

*Export all package level exports of tensorflow_transform, from the
tensorflow_transform.beam subpackage. This allows users to just import the
tensorflow_transform.beam subpackage for all functionality.*

This updates the example to work with tf.transform v0.11.0.