### PR TITLE
Use Setuptools Instead of Distutil for Build Command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ import platform
 import subprocess
 import sys
 from distutils import log
-from distutils.command.build_py import build_py as _build_py
 from distutils.spawn import find_executable
+from setuptools.command.build_py import build_py as _build_py
 from setuptools import Command
 from setuptools import find_packages
 from setuptools import setup


### PR DESCRIPTION
Referencing this issue: #50. We ran into the exact same issue not allowing the extension to be enabled in the notebook. When installing the extension, the `static` directory is looked up relative to the package location. When building a binary distribution, no `static` directory was created relative to the `tensorflow_model_analysis` package location.

To reproduce prior:

```
python setup.py bdist_wheel
unzip -l tensorflow_model_analysis-0.15.0.dev0-py2-none-any.whl | grep "tensorflow_model_analysis/static/*.js"
```

Using `setuptools` instead of `distutils` resolved the issue.