### PR TITLE
Add documentation for the `mode` parameter

### DIFF
--- a/g3doc/api_docs/python/tfma/load_eval_results.md
+++ b/g3doc/api_docs/python/tfma/load_eval_results.md
@@ -23,7 +23,12 @@ Run model analysis for a single model on multiple data sets.
 
 *   <b>`output_paths`</b>: A list of output paths of completed tfma runs.
 *   <b>`mode`</b>: The mode of the evaluation. Currently, tfma.DATA_CENTRIC_MODE
-    and tfma.MODEL_CENTRIC_MODE are supported.
+    and tfma.MODEL_CENTRIC_MODE are supported. In tfma.MODEL_CENTRIC_MODE, the
+    data will be presented in a model centric way which shows how a model
+    progresses over each run (i.e., the main axis will be the model run id). In
+    DATA_CENTRIC_MODE, the data will be presented in a data centric way which
+    shows how the latest version of the model performs as new evaluation data
+    become available (i.e., the main axis is the last data span).
 
 #### Returns:
 


### PR DESCRIPTION
I created this documentation based on this comment in the source code:
https://github.com/tensorflow/model-analysis/blob/86be9ae6f27e0bc98d0dad493848e0f8b9c36e0e/tensorflow_model_analysis/frontend/lib/series-data.js#L33
