### PR TITLE
Increase verbosity of error on mismatched shapes for tflite extractor

### DIFF
--- a/tensorflow_model_analysis/extractors/tflite_predict_extractor.py
+++ b/tensorflow_model_analysis/extractors/tflite_predict_extractor.py
@@ -95,7 +95,7 @@ class _TFLitePredictionDoFn(model_util.BatchReducibleDoFnWithModels):
         else:
           raise ValueError(
               'incompatible shape and data for feature: {}, got: {}, expected {}'.format(
-                  input_name, input_shape, feature_shape
+                  input_name, feature_shape, input_shape
               )
           )
         input_features[input_name] = tf.concat(

--- a/tensorflow_model_analysis/extractors/tflite_predict_extractor.py
+++ b/tensorflow_model_analysis/extractors/tflite_predict_extractor.py
@@ -94,7 +94,10 @@ class _TFLitePredictionDoFn(model_util.BatchReducibleDoFnWithModels):
           ]
         else:
           raise ValueError(
-              'incompatible shape and data for feature: {}'.format(input_name))
+              'incompatible shape and data for feature: {}, got: {}, expected {}'.format(
+                  input_name, input_shape, feature_shape
+              )
+          )
         input_features[input_name] = tf.concat(
             input_features[input_name], axis=0)
         if np.shape(input_features[input_name]) != tuple(i['shape']):


### PR DESCRIPTION
I got this exception while working on a model, but it wasn't verbose enough to debug - this way it will be easier to find out what is wrong.