### PR TITLE
Support running in JupyterLab

### DIFF
--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/labplugin.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/labplugin.js
@@ -1,0 +1,15 @@
+var plugin = require('./index');
+var base = require('@jupyter-widgets/base');
+
+module.exports = {
+  id: 'tensorflow_model_analysis',
+  requires: [base.IJupyterWidgetRegistry],
+  activate: function(app, widgets) {
+      widgets.registerWidget({
+          name: 'tensorflow_model_analysis',
+          version: plugin.version,
+          exports: plugin
+      });
+  },
+  autoStart: true
+};

--- a/tensorflow_model_analysis/notebook/jupyter/js/package.json
+++ b/tensorflow_model_analysis/notebook/jupyter/js/package.json
@@ -25,7 +25,10 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0",
+    "@jupyter-widgets/base": "^1.1 || ^2 || ^3",
     "lodash": "^4.17.4"
+  },
+  "jupyterlab": {
+    "extension": "lib/labplugin"
   }
 }


### PR DESCRIPTION
In JupyterLab, when executing something like `tfma.addons.fairness.view.widget_view.render_fairness_indicator(eval_result=eval_result)`, JupyterLab would say the model was not found.

This is because our extension didn't properly register models and views on the JS side. For example, the widget `FairnessIndicatorViewer` defined in the Python, refers to the JS model called `FairnessIndicatorModel` and the JS view called `FairnessIndicatorView`: https://github.com/tensorflow/model-analysis/blob/9c07f41f98654f8f405be76fe90674031c9c88c0/tensorflow_model_analysis/addons/fairness/notebook/jupyter/widget.py#L23

In order to correctly register the JS models and views for the extension, we need to add a key/value in package.json:

```
  "jupyterlab": {
    "extension": "lib/labplugin"
  }
```

lib/labplugin.js is the entry point of the extension. JupyterLab will run this file on load. That's where we register all the JS model and views.

These are the docs I've based my work on:
- https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Low%20Level.html: describes how the Python interacts with JS models and views.
- https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Low%20Level.html#Distribution shares a widget extension example.
  - here's the example package.json: https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/package.json
  - here's the example labplugin.js: https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/lib/labplugin.js