### PR TITLE
Support missing data-base-url

### DIFF
--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
@@ -21,7 +21,7 @@
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
 __webpack_public_path__ =
-    document.querySelector('body').getAttribute('data-base-url') || '' +
+    (document.querySelector('body').getAttribute('data-base-url') || '') +
     'nbextensions/tensorflow_model_analysis/';
 
 // Export widget models and views, and the npm package version number.

--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
@@ -21,7 +21,7 @@
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
 __webpack_public_path__ =
-    document.querySelector('body').getAttribute('data-base-url') +
+    document.querySelector('body').getAttribute('data-base-url') || '' +
     'nbextensions/tensorflow_model_analysis/';
 
 // Export widget models and views, and the npm package version number.


### PR DESCRIPTION
In Jupyter Lab, data-base-url is null, so the computed URL becomes [host]/nullnbextensions/tensorflow_model_analysis/vulcanized_tfma.js instead of [host]/nbextensions/tensorflow_model_analysis/vulcanized_tfma.js. With this fix, the TFMA Jupyter Lab extension will correctly load vulcanized_tfma.js.