### PR TITLE
Load vulcanized_tfma even when multiple tabs are open in JupyterLabs

### DIFF
--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
@@ -21,7 +21,7 @@
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
 __webpack_public_path__ =
-    (document.querySelector('body').getAttribute('data-base-url') || '') +
+    (document.querySelector('body').getAttribute('data-base-url') || '/') +
     'nbextensions/tensorflow_model_analysis/';
 
 // Export widget models and views, and the npm package version number.


### PR DESCRIPTION
In JupyterLabs, when opening the first tab, the URL is `http://[host]/lab`, and loading vulcanized_tfma works fine.

When opening a second tab, the URL looks like this: `http://[host]/lab/workspaces/auto-q?clone`. When the plugin tries to load `vulcanized_tfma.js`, it'll try to get it from `http://[host]/lab/workspaces/nbextension...` (relative path), but it should get it from `http://[host]/nbextension...` (absolute path) instead.