### PR TITLE
Modify to load the library without changing the variable used by Jupyterlab.

### DIFF
--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/index.js
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Entry point for the notebook bundle containing custom model definitions.
-//
-// Setup notebook base URL
-//
-// Some static assets may be required by the custom widget javascript. The base
-// url for the notebook is not known at build time and is therefore computed
-// dynamically.
-__webpack_public_path__ =
-    (document.querySelector('body').getAttribute('data-base-url') || '/') +
-    'nbextensions/tensorflow_model_analysis/';
 
 // Export widget models and views, and the npm package version number.
 module.exports = require('./widget.js');

--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/widget.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/widget.js
@@ -21,7 +21,9 @@ const version = require('../package.json').version;
  * Helper method to load the vulcanized templates.
  */
 function loadVulcanizedTemplate() {
-  const templateLocation = __webpack_public_path__ + 'vulcanized_tfma.js';
+  const templateLocation =
+      (document.querySelector('body').getAttribute('data-base-url') || '/') +
+      'nbextensions/tensorflow_model_analysis/vulcanized_tfma.js';
 
   // If the vulcanizes tempalets are not loaded yet, load it now.
   if (!document.querySelector('script[src="' + templateLocation + '"]')) {


### PR DESCRIPTION
The labextension of tensorflow_model_analysis changes a webpack-related variable. So loading of other modules is affected. The webpack tried to load the terminal library from the wrong url.Modified not to change the variable used in Jupyterlab.