### PR TITLE
Fix output type metric MinLabelPosition

### DIFF
--- a/tensorflow_model_analysis/metrics/min_label_position.py
+++ b/tensorflow_model_analysis/metrics/min_label_position.py
@@ -135,7 +135,7 @@ class _MinLabelPositionCombiner(beam.CombineFn):
           min_label_pos = i + 1  # Use 1-indexed positions
           break
       if min_label_pos:
-        accumulator.total_min_position += min_label_pos * example_weight
+        accumulator.total_min_position += min_label_pos * float(example_weight)
         accumulator.total_weighted_examples += float(example_weight)
     return accumulator
 

--- a/tensorflow_model_analysis/metrics/min_label_position_test.py
+++ b/tensorflow_model_analysis/metrics/min_label_position_test.py
@@ -163,10 +163,10 @@ class MinLabelPositionTest(testutil.TensorflowModelAnalysisTest,
           self.assertIn(key, got_metrics)
           if label_key == 'custom_label':
             # (1*1.0 + 3*2.0) / (1.0 + 2.0) = 2.333333
-            self.assertAllClose(got_metrics[key], np.array([2.333333]))
+            self.assertAllClose(got_metrics[key], 2.333333)
           else:
             # (2*1.0 + 1*2.0 + 1*3.0) / (1.0 + 2.0 + 3.0) = 1.166666
-            self.assertAllClose(got_metrics[key], np.array([1.166666]))
+            self.assertAllClose(got_metrics[key], 1.166666)
 
         except AssertionError as err:
           raise util.BeamAssertException(err)


### PR DESCRIPTION
when vizualizing metrics by slice it seems that the type of the output given by MinLabelPosition Metric is different from NDCG and other metrics.
Thus when trying to display the metric using `tfma.view.render_slicing_metrics`, Min Label Position does not display at all in the histogram.

Code to reproduce the bug : 
```
import os
import json
from typing import List

import pandas as pd
import tensorflow_model_analysis as tfma


df_data = pd.DataFrame({
    'score': [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
    'label': [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
    'query_id': [0] * 4 + [1] * 4 + [2] * 4 + [3] * 4, 
    'slice': ['aaa'] * 4 + ['bbb'] * 12
})

def set_eval_config(prediction: str, label: str, query_key: str, slices: List) -> tfma.EvalConfig:
    model_specs = [
      tfma.ModelSpec(
          prediction_key=prediction,
          label_key=label)
    ]

    metrics = [
        tfma.metrics.NDCG(name='ndcg', gain_key=label, top_k_list=[4]),
        tfma.metrics.MinLabelPosition(name='min_label_position', label_key='label'),
    ]

    metrics_specs = tfma.metrics.specs_from_metrics(metrics, query_key=query_key)

    slicing_specs = [tfma.SlicingSpec()]  # the empty slice represents the overall dataset  
    slicing_specs += [tfma.SlicingSpec(feature_keys=[slice]) for slice in slices]
    

    eval_config = tfma.EvalConfig(
        model_specs=model_specs,
        metrics_specs=metrics_specs,
        slicing_specs=slicing_specs)
    return eval_config

eval_config = set_eval_config(prediction='score', 
                                      label='label', 
                                      query_key='query_id',
                                      slices=['slice'])

eval_result = tfma.analyze_raw_data(df_data, 
                                        eval_config)

tfma.view.render_slicing_metrics(eval_result, slicing_column='slice')

#print(eval_result)
```
- pandas: 1.2.0
- tfma 0.26.0


This PR aims to fix the type output by the function.