### PR TITLE
Enable "pip install" commands to copy to user terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,28 +27,28 @@ pip install tensorflow-model-analysis
 
 pip install from https://pypi-nightly.tensorflow.org
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```Shell
 pip install -i https://pypi-nightly.tensorflow.org/simple tensorflow-model-analysis
-</pre>
+```
 
 pip install from the HEAD of the git:
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```Shell
 pip install git+https://github.com/tensorflow/model-analysis.git#egg=tensorflow_model_analysis
-</pre>
+```
 
 pip install from a released version directly from git:
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```Shell
 pip install git+https://github.com/tensorflow/model-analysis.git@v0.21.3#egg=tensorflow_model_analysis
-</pre>
+```
 
 If you have cloned the repository locally, and want to test your local change,
 pip install from a local folder.
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```Shell
 pip install -e $FOLDER_OF_THE_LOCAL_LOCATION
-</pre>
+```
 
 Note that protobuf must be installed correctly for the above option since it is
 building TFMA from source and it requires protoc and all of its includes

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Caution: TFMA may introduce backwards incompatible changes before version 1.0.
 The recommended way to install TFMA is using the
 [PyPI package](https://pypi.org/project/tensorflow-model-analysis/):
 
-<pre class="devsite-terminal devsite-click-to-copy">
+```Shell
 pip install tensorflow-model-analysis
-</pre>
+```
 
 pip install from https://pypi-nightly.tensorflow.org
 


### PR DESCRIPTION
I changed the "pip install" lines from `<pre class="devsite-terminal devsite-click-to-copy"> "pip install..." </pre>` to ` ```Shell "pip install..." ``` `  so a user can now easily copy the commands to their terminal window.