### PR TITLE
Fix jupiter integration

### DIFF
--- a/tensorflow_model_analysis/notebook/jupyter/js/lib/widget.js
+++ b/tensorflow_model_analysis/notebook/jupyter/js/lib/widget.js
@@ -35,7 +35,7 @@ function loadVulcanizedTemplate() {
     if (jupyterConfigData) {
       const configData = JSON.parse(jupyterConfigData.textContent || '');
       if (configData) {
-        baseUrl = configMap['baseUrl'] || '/';
+        baseUrl = configData['baseUrl'] || '/';
       }
     }
 


### PR DESCRIPTION
I'm not sure where the configMap comes from, but at least in jupiter-lab this causes the widget to not display (and error out with `ReferenceError: configMap is not defined`).

Also not sure how to update the build since the build resources seems to be included in the repository (tested by using ` jupyter lab build --dev-build=True --minimize=False` and modifying the static generated js file since all of this jupiter extensions are new to me).