### PR TITLE
fix: bump range for attrs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ setup_args = {
         'rouge-score>=0.1.2,<2',
         'scipy>=1.4.1,<2',
         'six>=1.12,<2',
-        'attrs>=19.3.0,<22',
+        'attrs>=19.3.0,<23',
         'tensorflow>=2.13,<3',
         'tensorflow-metadata'
         + select_constraint(


### PR DESCRIPTION
This PR bumps the range for `attrs` since I've seen it causing a conflict with many packages (like `jsonschema`, `nbformat`,  `gcsfs`, `aiohttp`).